### PR TITLE
Exposing module declaration on published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"main": "index.js",
 	"files": [
 		"/index.js",
+		"/index.d.ts",
 		"/examples"
 	],
 	"dependencies": {


### PR DESCRIPTION
The `index.d.ts` file introduced on #1 is not being shipped with the lib files on the package published on npm.

I used `npm link` to test the changes locally, then all of the files where linked to the package directory on `node_modules`, but this does not happen when the package is installed throug npm.